### PR TITLE
Add Default Font for Windows

### DIFF
--- a/style.css
+++ b/style.css
@@ -20,7 +20,7 @@ body {
     width: 100%;
     border: none;
     margin: 0;
-    font-family: 'Menlo', 'Monaco', courier, monospace;
+    font-family: 'Menlo', 'Monaco', 'Consolas', courier, monospace;
     font-size: 16px;
     line-height: 1.5;
     box-sizing: border-box;


### PR DESCRIPTION
By default, Windows doesn't have both Menlo and Monaco fonts, so it renders `Courier New` which looks ugly. I suggest adding `Consolas` as font for Windows